### PR TITLE
fix: stop Select All from reaching the grid while an overlay is open

### DIFF
--- a/gpui-app/src/views/actions_nav.rs
+++ b/gpui-app/src/views/actions_nav.rs
@@ -445,6 +445,8 @@ pub(crate) fn bind(
             }
             if this.mode == Mode::Edit {
                 this.select_all_edit(cx);
+            } else if this.mode.is_overlay() {
+                return;
             } else {
                 this.select_all(cx);
             }


### PR DESCRIPTION
## Summary
- cmd-A / ctrl-A leaked past the command palette (and other overlays) into the grid and selected the whole workbook, because the `SelectAll` action handler only guarded `Mode::ColorPicker` and `Mode::Edit`
- Reuse the existing `Mode::is_overlay()` guard (already used elsewhere to block grid input while a dialog is open) so `SelectAll` is swallowed while any overlay/dialog is open

## Follow-up (not in this PR — design decision)
Cross-platform convention is that cmd/ctrl-A selects the *text* in a focused input (VS Code's palette, Spotlight, browser address bars). The palette's search field is currently a plain `String` with no cursor/selection model, so implementing real text-selection there is a separate, larger change and is intentionally deferred rather than bundled into this fix.

## Test plan
- [x] `cargo build -p visigrid-gpui` succeeds
- [x] Manually verified: opened the command palette, pressed cmd-A — grid selection/count unchanged, palette stayed open
- [x] Sanity-checked cmd-A still selects the region/sheet as before when no overlay is open

Closes #9