### PR TITLE
IME composition for CJK input (#14)

### DIFF
--- a/gpui-app/src/app.rs
+++ b/gpui-app/src/app.rs
@@ -417,6 +417,9 @@ pub struct Spreadsheet {
     pub edit_value: String,
     pub edit_cursor: usize,  // Cursor position within edit_value (byte offset, 0..=len)
     pub edit_selection_anchor: Option<usize>,  // Selection start (None = no selection)
+    /// Provisional IME text, as a byte range into `edit_value` (None = not composing).
+    /// The next composition keystroke replaces this range instead of appending after it.
+    pub edit_marked_range: Option<std::ops::Range<usize>>,
     pub edit_original: String,
     pub edit_scroll_x: f32,  // Horizontal scroll offset for in-cell editor (<=0, updated by ensure_caret_visible)
     pub(crate) edit_scroll_dirty: bool, // True when caret/text changed; triggers ensure_caret_visible once
@@ -1077,6 +1080,7 @@ impl Spreadsheet {
             edit_value: String::new(),
             edit_cursor: 0,
             edit_selection_anchor: None,
+            edit_marked_range: None,
             edit_original: String::new(),
             edit_scroll_x: 0.0,
             edit_scroll_dirty: false,
@@ -2220,6 +2224,7 @@ impl Spreadsheet {
                 } else {
                     // Grid navigation: start formula edit with =FUNC(
                     self.edit_original = self.sheet(cx).get_raw(self.view_state.selected.0, self.view_state.selected.1);
+                    self.clear_edit_marks();
                     self.edit_value = format!("={}(", name);
                     self.edit_cursor = self.edit_value.len();  // Byte offset at end
                     self.mode = Mode::Formula;
@@ -4058,6 +4063,7 @@ impl Spreadsheet {
             // Start editing then insert newline
             let (row, col) = self.view_state.selected;
             self.edit_original = self.sheet(cx).get_raw(row, col);
+            self.clear_edit_marks();
             self.edit_value = self.edit_original.clone();
             self.edit_cursor = self.edit_value.len();
             self.mode = Mode::Edit;
@@ -4351,7 +4357,32 @@ impl Render for Spreadsheet {
             }
         }
 
-        views::render_spreadsheet(self, window, cx)
+        let root = views::render_spreadsheet(self, window, cx);
+
+        // Register the IME input handler for this frame.
+        //
+        // `Window::handle_input` has to run during paint, and it only takes effect while
+        // the handle is focused, so it rides along on a zero-size canvas rather than a
+        // full-size overlay: an overlay that covers the grid would sit in front of every
+        // click. The candidate-window rectangle comes from `bounds_for_range` instead of
+        // from these bounds, so the canvas having no area costs nothing.
+        let ime_entity = cx.entity();
+        let ime_focus = self.focus_handle.clone();
+        let ime_hook = gpui::canvas(
+            |_bounds, _window, _cx| {},
+            move |bounds, _prepaint, window, cx| {
+                window.handle_input(
+                    &ime_focus,
+                    gpui::ElementInputHandler::new(bounds, ime_entity),
+                    cx,
+                );
+            },
+        )
+        .absolute()
+        .w(gpui::px(0.0))
+        .h(gpui::px(0.0));
+
+        gpui::div().size_full().child(root).child(ime_hook)
     }
 }
 

--- a/gpui-app/src/editing.rs
+++ b/gpui-app/src/editing.rs
@@ -33,6 +33,7 @@ impl Spreadsheet {
 
     /// Reset formula/edit transient state. Called on every exit from edit mode.
     fn reset_edit_state(&mut self) {
+        self.clear_edit_marks();
         self.formula_nav_mode = crate::mode::FormulaNavMode::Point;
         self.formula_nav_manual_override = None;
         self.formula_ref_cell = None;
@@ -41,6 +42,17 @@ impl Spreadsheet {
         self.formula_edit_cell = None;
         self.formula_ref_sheet = None;
         self.formula_cross_sheet_name = None;
+    }
+
+    /// Forget any selection and any IME composition that belonged to a previous edit.
+    ///
+    /// Called by every path that starts or ends an edit, including the ones that assign
+    /// `edit_value` and `mode` directly instead of going through `start_edit`. A range
+    /// left over from an earlier buffer would otherwise point into the new one, and the
+    /// IME handler would treat it as a live composition or selection.
+    pub(crate) fn clear_edit_marks(&mut self) {
+        self.edit_selection_anchor = None;
+        self.edit_marked_range = None;
     }
 
     /// Recompute edit mode based on current edit buffer content.
@@ -111,7 +123,7 @@ impl Spreadsheet {
         self.formula_bar_cache_dirty = true;  // Rebuild hit-test cache
         self.formula_bar_scroll_x = 0.0;
         self.active_editor = EditorSurface::Cell;  // Default to cell editor
-        self.edit_selection_anchor = None;
+        self.clear_edit_marks();
 
         // Debug assert: cursor must be valid
         debug_assert!(
@@ -188,7 +200,7 @@ impl Spreadsheet {
         self.formula_bar_cache_dirty = true;  // Rebuild hit-test cache
         self.formula_bar_scroll_x = 0.0;
         self.active_editor = EditorSurface::Cell;  // Default to cell editor
-        self.edit_selection_anchor = None;
+        self.clear_edit_marks();
         // Record home sheet and cell for cross-sheet formula references
         self.formula_home_sheet = Some(self.wb(cx).active_sheet_index());
         self.formula_edit_cell = Some((row, col));
@@ -1286,6 +1298,7 @@ impl Spreadsheet {
             }
 
             self.edit_original = self.sheet(cx).get_raw(row, col);
+            self.clear_edit_marks();
             self.edit_value = c.to_string();
             self.edit_cursor = c.len_utf8();  // Byte offset after first char
 
@@ -1321,7 +1334,7 @@ impl Spreadsheet {
     }
 
     /// Finalize the current formula reference (clear the active reference state)
-    fn finalize_formula_reference(&mut self) {
+    pub(crate) fn finalize_formula_reference(&mut self) {
         self.formula_ref_cell = None;
         self.formula_ref_end = None;
     }

--- a/gpui-app/src/fill.rs
+++ b/gpui-app/src/fill.rs
@@ -303,6 +303,7 @@ impl Spreadsheet {
 
         // Enter edit mode with the formula
         self.edit_original = self.sheet(cx).get_raw(row, col);
+        self.clear_edit_marks();
         self.edit_value = formula;
         self.edit_cursor = self.edit_value.chars().count(); // Cursor at end
         self.mode = Mode::Formula;

--- a/gpui-app/src/ime.rs
+++ b/gpui-app/src/ime.rs
@@ -1,0 +1,671 @@
+//! IME (Input Method Editor) support for composed text entry.
+//!
+//! Without this, every keystroke reaches the app through `keystroke.key_char` and is
+//! appended one character at a time. That works for Latin scripts but breaks every
+//! input method that composes: Korean, Japanese, Chinese, and dead-key layouts.
+//!
+//! Typing "한글" on a 2-Set Korean keyboard used to land `ㅎㅏㄴㄱㅡㄹ` in the cell:
+//! six standalone compatibility jamo (U+314E U+314F U+3134 U+3131 U+3161 U+3139)
+//! instead of two composed syllables (U+D55C U+AE00). The damage is not recoverable
+//! afterwards. Unicode normalization does not fix it, because compatibility jamo are
+//! distinct characters from the conjoining jamo that NFC composes; NFKC makes it worse
+//! by fusing them wrongly (`하ᄂ그ᄅ`), having lost the information about which jamo were
+//! leading and which were trailing.
+//!
+//! The fix is to implement `EntityInputHandler` so the platform can drive composition:
+//! it sends provisional ("marked") text while the user is mid-syllable and replaces it
+//! with the committed text when the syllable closes. GPUI already exposes the whole
+//! protocol; this module just connects the spreadsheet's edit buffer to it.
+//!
+//! Once a handler is registered, committed text arrives here for every layout, not only
+//! for composing ones, so this is the typing path on macOS. Committed text therefore
+//! goes through `insert_char`, which owns the formula behaviours. How the key-down path
+//! and this one share the work is explained at the cell branch in `key_handler.rs`.
+//!
+//! Offsets are the fiddly part. The edit buffer indexes by UTF-8 byte, the platform
+//! protocol indexes by UTF-16 code unit, and the two only coincide for ASCII. Every
+//! boundary crossing goes through the converters below.
+//!
+//! The composition state machine lives in [`ImeBuffer`], deliberately free of `Window`
+//! and `Context` so it can be exercised without a running app. The parts that are ours
+//! rather than the platform's are tested here; the live keyboard is reserved for
+//! confirming that the platform calls into this handler at all.
+
+use gpui::{Bounds, Context, EntityInputHandler, Pixels, UTF16Selection, Window};
+use std::ops::Range;
+
+use crate::app::Spreadsheet;
+use crate::mode::{InspectorTab, Mode};
+use crate::rewind_state::EditorSurface;
+
+/// UTF-8 byte offset to UTF-16 code unit offset.
+///
+/// Counts rather than slices so an offset inside a multi-byte character (the editor's
+/// cursor can land there after autocomplete, which stores a char index) rounds down
+/// instead of panicking.
+fn byte_to_utf16(s: &str, byte: usize) -> usize {
+    s.char_indices()
+        .take_while(|(idx, ch)| idx + ch.len_utf8() <= byte)
+        .map(|(_, ch)| ch.len_utf16())
+        .sum()
+}
+
+/// UTF-16 code unit offset to UTF-8 byte offset.
+///
+/// Offsets that land inside a surrogate pair round down to the start of that character,
+/// which keeps the result on a char boundary and so safe to slice with.
+fn utf16_to_byte(s: &str, utf16: usize) -> usize {
+    let mut seen = 0usize;
+    for (byte_idx, ch) in s.char_indices() {
+        if seen >= utf16 {
+            return byte_idx;
+        }
+        let next = seen + ch.len_utf16();
+        if next > utf16 {
+            // The offset falls inside this character, which only happens between the two
+            // halves of a surrogate pair. Round down to the character start so the result
+            // stays a valid slice index.
+            return byte_idx;
+        }
+        seen = next;
+    }
+    s.len()
+}
+
+fn byte_range_to_utf16(s: &str, r: Range<usize>) -> Range<usize> {
+    byte_to_utf16(s, r.start)..byte_to_utf16(s, r.end)
+}
+
+fn utf16_range_to_byte(s: &str, r: Range<usize>) -> Range<usize> {
+    utf16_to_byte(s, r.start)..utf16_to_byte(s, r.end)
+}
+
+/// The slice of edit state that composition touches, and the rules for mutating it.
+///
+/// All offsets are UTF-8 byte indices, matching the surrounding editor. Conversion to
+/// and from the platform's UTF-16 offsets happens at the trait boundary below, so this
+/// type never sees a UTF-16 index except for the caret hint inside marked text, which
+/// the platform expresses relative to the marked run.
+#[derive(Default)]
+pub(crate) struct ImeBuffer {
+    pub text: String,
+    pub cursor: usize,
+    pub selection_anchor: Option<usize>,
+    /// Provisional text the input method may still revise. `None` when not composing.
+    pub marked: Option<Range<usize>>,
+}
+
+impl ImeBuffer {
+    fn selection(&self) -> Range<usize> {
+        match self.selection_anchor {
+            Some(anchor) if anchor != self.cursor => {
+                anchor.min(self.cursor)..anchor.max(self.cursor)
+            }
+            _ => self.cursor..self.cursor,
+        }
+    }
+
+    /// What the platform means by a `None` range: wherever input would go right now.
+    ///
+    /// During composition that is the marked run, because the next keystroke of the same
+    /// syllable revises it rather than appending after it. Otherwise it is the selection,
+    /// which collapses to the caret when nothing is selected.
+    fn default_range(&self) -> Range<usize> {
+        self.marked.clone().unwrap_or_else(|| self.selection())
+    }
+
+    /// Remove what a commit replaces and leave the caret where the committed text goes:
+    /// the explicit range if the platform gave one, else the marked run. Ends any
+    /// composition in progress.
+    ///
+    /// A plain selection is left alone: `insert_char`, which types the committed text
+    /// afterwards, deletes the selection itself, and doing it there keeps the IME path
+    /// and the key-down path on one implementation.
+    pub(crate) fn begin_commit(&mut self, range: Option<Range<usize>>) {
+        let Some(r) = range.or_else(|| self.marked.take()) else {
+            return;
+        };
+        self.text.replace_range(r.clone(), "");
+        self.cursor = r.start;
+        self.selection_anchor = None;
+        self.marked = None;
+    }
+
+    /// Test model of a full commit: [`Self::begin_commit`] followed by a plain insert
+    /// over the selection, standing in for the app's per-character `insert_char` calls.
+    #[cfg(test)]
+    fn replace(&mut self, range: Option<Range<usize>>, text: &str) {
+        self.begin_commit(range);
+        let sel = self.selection();
+        self.text.replace_range(sel.clone(), text);
+        self.cursor = sel.start + text.len();
+        self.selection_anchor = None;
+    }
+
+    /// Write provisional text and keep it marked so the next revision replaces it.
+    ///
+    /// `caret_utf16` is the platform's requested caret position measured from the start
+    /// of the new text, not from the start of the buffer. Empty text means the input
+    /// method abandoned the composition, which clears the mark rather than leaving a
+    /// zero-length one behind.
+    pub(crate) fn replace_and_mark(
+        &mut self,
+        range: Option<Range<usize>>,
+        text: &str,
+        caret_utf16: Option<Range<usize>>,
+    ) {
+        let r = range.unwrap_or_else(|| self.default_range());
+        let start = r.start;
+        self.text.replace_range(r, text);
+        self.selection_anchor = None;
+
+        if text.is_empty() {
+            self.marked = None;
+            self.cursor = start;
+            return;
+        }
+
+        let end = start + text.len();
+        self.marked = Some(start..end);
+        self.cursor = match caret_utf16 {
+            Some(sel) => start + utf16_to_byte(&self.text[start..end], sel.end),
+            None => end,
+        };
+    }
+}
+
+impl Spreadsheet {
+    /// The marked run, but only while it can mean anything.
+    ///
+    /// Some paths leave edit mode without going through `reset_edit_state` (opening
+    /// Find or GoTo mid-edit, F12 to a named range), and buffer edits that bypass this
+    /// module can move the bytes it points at. A range that is not inside the current
+    /// buffer on char boundaries, or that belongs to an edit that has ended, is treated
+    /// as no composition rather than used.
+    fn ime_marked_range(&self) -> Option<Range<usize>> {
+        let r = self.edit_marked_range.clone()?;
+        let text = &self.edit_value;
+        let valid = self.mode.is_editing()
+            && r.start <= r.end
+            && text.is_char_boundary(r.start)
+            && text.is_char_boundary(r.end);
+        valid.then_some(r)
+    }
+
+    /// Whether typed text belongs to the cell editor right now.
+    ///
+    /// Several text boxes live as flags on Navigation rather than as modes: sheet
+    /// rename, the filter and validation dropdown searches, an open menu, KeyTips, the
+    /// close-confirm dialog, the Lua console, and the surfaces with their own focus
+    /// handle (terminal, format bar). Each takes printable keys in `handle_key_down`
+    /// before the cell branch, and the platform still offers the IME's text to this
+    /// handler in those states, so the handler has to make the same call and decline.
+    /// This guards both `replace_*` entry points, which is what protects Linux, where
+    /// `accepts_text_input` is not consulted.
+    fn cell_owns_text_input(&self, window: &Window) -> bool {
+        if self.terminal_has_focus(window)
+            || self.ui.format_bar.is_active(window)
+            || self.keytips_active
+            || self.open_menu.is_some()
+            || self.lua_console.visible
+            || self.close_confirm_visible
+            || self.filter_dropdown_col.is_some()
+            || self.is_validation_dropdown_open()
+            || self.renaming_sheet.is_some()
+        {
+            return false;
+        }
+        matches!(self.mode, Mode::Navigation | Mode::Edit | Mode::Formula)
+    }
+
+    /// Composition on a Ready cell starts an edit with an empty buffer, the way the
+    /// first plain keystroke does. Returns false when the cell refused (spill receiver,
+    /// preview), in which case the input is dropped rather than written into a buffer
+    /// nobody will commit.
+    ///
+    /// `start_edit_clear` is deliberate, for the committed path too: it applies the
+    /// merged-cell redirect and the preview block that the inline first-keystroke
+    /// branch of `insert_char` skips, so a Latin and a composed first keystroke land
+    /// in the same cell. Do not "fix" the asymmetry by routing through `insert_char`.
+    fn ime_ensure_editing(&mut self, cx: &mut Context<Self>) -> bool {
+        if !self.mode.is_editing() {
+            self.start_edit_clear(cx);
+        }
+        self.mode.is_editing()
+    }
+
+    /// Lift the composition state out of the app so [`ImeBuffer`] can operate on it.
+    fn ime_take_buffer(&mut self) -> ImeBuffer {
+        let marked = self.ime_marked_range();
+        ImeBuffer {
+            text: std::mem::take(&mut self.edit_value),
+            cursor: self.edit_cursor,
+            selection_anchor: self.edit_selection_anchor,
+            marked,
+        }
+    }
+
+    fn ime_put_buffer(&mut self, buf: ImeBuffer) {
+        self.edit_value = buf.text;
+        self.edit_cursor = buf.cursor;
+        self.edit_selection_anchor = buf.selection_anchor;
+        self.edit_marked_range = buf.marked;
+    }
+
+    /// Everything the rest of the app expects after the buffer changed under it.
+    /// Mirrors the tail of `insert_char`, for the paths that do not go through it.
+    fn ime_after_buffer_change(&mut self, cx: &mut Context<Self>) {
+        // Typing '=' first should still drop into formula mode, and a composition that
+        // deletes back past the '=' should leave it.
+        self.recompute_edit_mode();
+        if self.mode.is_formula() {
+            self.update_formula_refs();
+            self.clear_formula_nav_override();
+            self.update_formula_nav_mode();
+        }
+
+        self.autocomplete_suppressed = false;
+        self.reset_caret_activity();
+        self.edit_scroll_dirty = true;
+        self.formula_bar_cache_dirty = true;
+        self.update_autocomplete(cx);
+        cx.notify();
+    }
+}
+
+impl EntityInputHandler for Spreadsheet {
+    fn accepts_text_input(&self, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        // On macOS this decides whether an active IME may compose a printable key
+        // before the app sees it. A Ready cell has to say yes, or composition cannot
+        // start on the first keystroke (Excel's behaviour, and the whole point here).
+        //
+        // Beyond the states where the cell does not own text at all, decline while a
+        // Navigation letter is a command the key-down path must see first: vim motions,
+        // the Names inspector filter, and Space with a history entry selected (hold to
+        // peek). Those keys still reach the cell handler when they fall through, so
+        // digits and operators in vim mode keep starting an edit.
+        if !self.cell_owns_text_input(window) {
+            return false;
+        }
+        if self.mode.is_navigation() {
+            let names_filter =
+                self.inspector_visible && self.inspector_tab == InspectorTab::Names;
+            let history_peek =
+                self.selected_history_id.is_some() && self.history_highlight_range.is_some();
+            if names_filter || history_peek || self.vim_mode_enabled(cx) {
+                return false;
+            }
+        }
+        true
+    }
+
+    fn text_for_range(
+        &mut self,
+        range_utf16: Range<usize>,
+        adjusted_range: &mut Option<Range<usize>>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<String> {
+        let byte_range = utf16_range_to_byte(&self.edit_value, range_utf16);
+        *adjusted_range = Some(byte_range_to_utf16(&self.edit_value, byte_range.clone()));
+        Some(self.edit_value[byte_range].to_string())
+    }
+
+    fn selected_text_range(
+        &mut self,
+        _ignore_disabled_input: bool,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<UTF16Selection> {
+        if !self.mode.is_editing() {
+            // Outside an edit the buffer is empty and a selection anchor may be stale
+            // (some exits skip `reset_edit_state`), so do not consult it. An empty
+            // selection at the origin, not None: None tells the platform there is no
+            // text field, and some input methods then refuse to start composing.
+            return Some(UTF16Selection { range: 0..0, reversed: false });
+        }
+        let (start, end) = self
+            .edit_selection_range()
+            .unwrap_or((self.edit_cursor, self.edit_cursor));
+        let reversed = self.edit_cursor <= start && start != end;
+        Some(UTF16Selection {
+            range: byte_range_to_utf16(&self.edit_value, start..end),
+            reversed,
+        })
+    }
+
+    fn marked_text_range(
+        &self,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Range<usize>> {
+        let marked = self.ime_marked_range()?;
+        Some(byte_range_to_utf16(&self.edit_value, marked))
+    }
+
+    fn unmark_text(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        self.edit_marked_range = None;
+        cx.notify();
+    }
+
+    fn replace_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        text: &str,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.cell_owns_text_input(window) {
+            return;
+        }
+
+        // Same filter as the key-down path: control characters are commands, not text.
+        let text: String = text.chars().filter(|c| !c.is_control()).collect();
+
+        // An empty commit that replaces nothing is noise, not typing: Windows sends one
+        // whenever a Japanese IME reports no composition string. It must not open an
+        // edit on a Ready cell, or the next Enter would commit "" over the value.
+        if text.is_empty() && range_utf16.is_none() && self.ime_marked_range().is_none() {
+            return;
+        }
+
+        if !self.ime_ensure_editing(cx) {
+            return;
+        }
+
+        // Clear what the commit replaces (the marked run, usually), then type the
+        // replacement through insert_char so formula entry keeps its behaviours: an
+        // operator finalises the pending reference, a leading `=` switches to Formula
+        // mode, autocomplete suppression resets.
+        let mut buf = self.ime_take_buffer();
+        let range = range_utf16.map(|r| utf16_range_to_byte(&buf.text, r));
+        buf.begin_commit(range);
+        self.ime_put_buffer(buf);
+
+        let mut inserted = false;
+        for c in text.chars() {
+            self.insert_char(c, cx);
+            inserted = true;
+        }
+        if !inserted {
+            // Nothing typed, so nothing ran the post-edit work for the removal above.
+            self.ime_after_buffer_change(cx);
+        }
+        self.update_edit_scroll(window);
+    }
+
+    fn replace_and_mark_text_in_range(
+        &mut self,
+        range_utf16: Option<Range<usize>>,
+        new_text: &str,
+        new_selected_range_utf16: Option<Range<usize>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.cell_owns_text_input(window) {
+            return;
+        }
+        // An empty preedit while not editing is a composition being abandoned before
+        // it wrote anything; there is nothing to open an edit for.
+        if new_text.is_empty() && !self.mode.is_editing() {
+            return;
+        }
+        if !self.ime_ensure_editing(cx) {
+            return;
+        }
+
+        // Provisional text is typing as far as reference picking is concerned: a
+        // non-operator keystroke ends the pending reference in insert_char, and this
+        // does the same.
+        if self.mode.is_formula() {
+            self.finalize_formula_reference();
+        }
+
+        let mut buf = self.ime_take_buffer();
+        let range = range_utf16.map(|r| utf16_range_to_byte(&buf.text, r));
+        buf.replace_and_mark(range, new_text, new_selected_range_utf16);
+        self.ime_put_buffer(buf);
+        self.ime_after_buffer_change(cx);
+        self.update_edit_scroll(window);
+    }
+
+    fn bounds_for_range(
+        &mut self,
+        _range_utf16: Range<usize>,
+        _element_bounds: Bounds<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<Bounds<Pixels>> {
+        // Positions the input method's candidate window. `element_bounds` is useless here
+        // because the handler is registered on a zero-size canvas, so the rectangle comes
+        // from whichever surface is being edited. The grid case is the cell, not the
+        // caret within it, which is where `open_context_menu` anchors too.
+        let rect = match self.active_editor {
+            EditorSurface::FormulaBar => self.formula_bar_text_rect,
+            _ => {
+                let cell = self.active_cell_rect();
+                let (x, y) = self.grid_layout.grid_body_origin;
+                Bounds {
+                    origin: gpui::point(gpui::px(x + cell.x), gpui::px(y + cell.y)),
+                    size: gpui::size(gpui::px(cell.width), gpui::px(cell.height)),
+                }
+            }
+        };
+        Some(rect)
+    }
+
+    fn character_index_for_point(
+        &mut self,
+        _point: gpui::Point<Pixels>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) -> Option<usize> {
+        // Used for mouse-driven queries into marked text (dictionary lookup and the
+        // like). Declining is safe; composition does not depend on it.
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{byte_to_utf16, utf16_to_byte, ImeBuffer};
+
+    // ---- offset conversion ------------------------------------------------------
+
+    #[test]
+    fn offsets_round_trip_for_ascii() {
+        let s = "abc";
+        for b in 0..=s.len() {
+            assert_eq!(utf16_to_byte(s, byte_to_utf16(s, b)), b);
+        }
+    }
+
+    #[test]
+    fn offsets_round_trip_for_hangul() {
+        // Each syllable is 3 UTF-8 bytes and 1 UTF-16 unit, so the two indices diverge.
+        let s = "한글";
+        assert_eq!(s.len(), 6);
+        assert_eq!(byte_to_utf16(s, 6), 2);
+        assert_eq!(byte_to_utf16(s, 3), 1);
+        assert_eq!(utf16_to_byte(s, 1), 3);
+        assert_eq!(utf16_to_byte(s, 2), 6);
+    }
+
+    #[test]
+    fn offsets_round_trip_for_astral_chars() {
+        // An emoji is 4 UTF-8 bytes and 2 UTF-16 units (a surrogate pair).
+        let s = "a\u{1F600}b";
+        assert_eq!(byte_to_utf16(s, s.len()), 4);
+        // Landing inside the pair rounds down to the start of the emoji.
+        assert_eq!(utf16_to_byte(s, 2), 1);
+        assert_eq!(utf16_to_byte(s, 3), 5);
+    }
+
+    #[test]
+    fn offsets_past_the_end_or_inside_a_char_do_not_panic() {
+        let s = "한";
+        assert_eq!(utf16_to_byte(s, 99), s.len());
+        assert_eq!(byte_to_utf16(s, 99), 1);
+        // A byte offset inside the 3-byte syllable rounds down to its start.
+        assert_eq!(byte_to_utf16(s, 1), 0);
+        assert_eq!(byte_to_utf16("한글", 4), 1);
+    }
+
+    // ---- composition lifecycle --------------------------------------------------
+    //
+    // The sequences below are what macOS sends through NSTextInputClient while a
+    // 2-Set Korean keyboard composes. `None` for the range means "the marked run if
+    // composing, the selection otherwise", which is why most steps pass None.
+
+    /// Type g, k, s, r, m, f, which is the 2-Set Korean spelling of "한글".
+    ///
+    /// The interesting step is the fourth: pressing the leading consonant of the second
+    /// syllable commits the first one and opens a new composition, so the buffer has to
+    /// stop treating the old marked run as the write target.
+    #[test]
+    fn korean_two_syllables_compose() {
+        let mut b = ImeBuffer::default();
+
+        b.replace_and_mark(None, "ㅎ", None);
+        assert_eq!(b.text, "ㅎ");
+        assert_eq!(b.marked, Some(0..3));
+
+        b.replace_and_mark(None, "하", None);
+        assert_eq!(b.text, "하");
+        assert_eq!(b.marked, Some(0..3));
+
+        b.replace_and_mark(None, "한", None);
+        assert_eq!(b.text, "한");
+
+        // 'r' closes the first syllable and starts the second.
+        b.replace(None, "한");
+        assert_eq!(b.marked, None);
+        b.replace_and_mark(None, "ㄱ", None);
+        assert_eq!(b.text, "한ㄱ");
+        assert_eq!(b.marked, Some(3..6));
+
+        b.replace_and_mark(None, "그", None);
+        b.replace_and_mark(None, "글", None);
+        b.replace(None, "글");
+
+        assert_eq!(b.text, "한글");
+        assert_eq!(b.text.chars().count(), 2);
+        assert_eq!(b.marked, None);
+        assert_eq!(b.cursor, b.text.len());
+    }
+
+    /// What the app does on commit: clear the marked run, then type through
+    /// `insert_char`. The caret must sit where the run was so the typed characters land
+    /// in its place, and the mark must be gone so a stray commit afterwards appends
+    /// instead of replacing.
+    #[test]
+    fn begin_commit_removes_the_marked_run_and_parks_the_caret_there() {
+        let mut b = ImeBuffer {
+            text: "매출 ".to_string(),
+            cursor: "매출 ".len(),
+            ..Default::default()
+        };
+        b.replace_and_mark(None, "합", None);
+        assert_eq!(b.text, "매출 합");
+
+        b.begin_commit(None);
+        assert_eq!(b.text, "매출 ");
+        assert_eq!(b.cursor, "매출 ".len());
+        assert_eq!(b.marked, None);
+        assert_eq!(b.selection_anchor, None);
+    }
+
+    /// With no composition a commit removes nothing, which is the case every ASCII
+    /// keystroke takes. A selection is deliberately left in place for `insert_char`.
+    #[test]
+    fn begin_commit_without_composition_leaves_the_buffer_alone() {
+        let mut b = ImeBuffer {
+            text: "=A1+".to_string(),
+            cursor: 4,
+            selection_anchor: Some(1),
+            ..Default::default()
+        };
+        b.begin_commit(None);
+        assert_eq!(b.text, "=A1+");
+        assert_eq!(b.cursor, 4);
+        assert_eq!(b.selection_anchor, Some(1));
+    }
+
+    #[test]
+    fn backspacing_mid_composition_shrinks_the_marked_run() {
+        let mut b = ImeBuffer::default();
+        b.replace_and_mark(None, "한", None);
+        assert_eq!(b.marked, Some(0..3));
+
+        // The input method decomposes rather than deleting a whole character.
+        b.replace_and_mark(None, "하", None);
+        assert_eq!(b.text, "하");
+        assert_eq!(b.marked, Some(0..3));
+    }
+
+    #[test]
+    fn abandoning_a_composition_clears_the_mark() {
+        let mut b = ImeBuffer::default();
+        b.replace_and_mark(None, "ㅎ", None);
+        b.replace_and_mark(None, "", None);
+
+        assert_eq!(b.text, "");
+        assert_eq!(b.marked, None);
+        assert_eq!(b.cursor, 0);
+    }
+
+    #[test]
+    fn composing_after_existing_text_appends() {
+        let mut b = ImeBuffer {
+            text: "매출 ".to_string(),
+            cursor: "매출 ".len(),
+            ..Default::default()
+        };
+        b.replace_and_mark(None, "합", None);
+        b.replace(None, "합");
+
+        assert_eq!(b.text, "매출 합");
+        assert_eq!(b.cursor, b.text.len());
+    }
+
+    #[test]
+    fn composing_over_a_selection_replaces_it() {
+        let mut b = ImeBuffer {
+            text: "abcdef".to_string(),
+            cursor: 5,
+            selection_anchor: Some(1),
+            ..Default::default()
+        };
+        b.replace_and_mark(None, "한", None);
+
+        assert_eq!(b.text, "a한f");
+        assert_eq!(b.marked, Some(1..4));
+        assert_eq!(b.selection_anchor, None);
+    }
+
+    #[test]
+    fn caret_hint_inside_marked_text_is_honoured() {
+        let mut b = ImeBuffer::default();
+        // Japanese input often parks the caret inside a longer marked run.
+        b.replace_and_mark(None, "にほんご", Some(0..2));
+
+        assert_eq!(b.text, "にほんご");
+        assert_eq!(b.marked, Some(0..12));
+        // Two UTF-16 units into the run is two 3-byte characters in.
+        assert_eq!(b.cursor, 6);
+    }
+
+    #[test]
+    fn explicit_range_overrides_the_default_target() {
+        let mut b = ImeBuffer {
+            text: "abcdef".to_string(),
+            cursor: 6,
+            ..Default::default()
+        };
+        b.replace(Some(1..3), "X");
+
+        assert_eq!(b.text, "aXdef");
+        assert_eq!(b.cursor, 2);
+    }
+
+}

--- a/gpui-app/src/main.rs
+++ b/gpui-app/src/main.rs
@@ -1069,6 +1069,17 @@ mod symbol_font_tests {
         if (0x3000..=0x9FFF).contains(&cp) || (0xFE00..=0xFE0F).contains(&cp) {
             return false; // CJK and variation selectors need their own fonts
         }
+        // Hangul, for the same reason, and it does not live next to the CJK block:
+        // syllables sit at U+AC00 and the jamo that compose them at U+1100, either
+        // side of the range above. Eleven thousand syllables are not going into a
+        // symbol font. Leaving the gap meant a source file that merely mentioned
+        // Korean failed this test while one mentioning Japanese passed.
+        if (0x1100..=0x11FF).contains(&cp)
+            || (0xA960..=0xA97F).contains(&cp)
+            || (0xAC00..=0xD7FF).contains(&cp)
+        {
+            return false;
+        }
         true
     }
 

--- a/gpui-app/src/main.rs
+++ b/gpui-app/src/main.rs
@@ -34,6 +34,7 @@ mod formula_refs;
 mod grid_ops;
 mod hints;
 mod history;
+mod ime;
 mod hub;
 mod cloud;
 mod impact_preview;

--- a/gpui-app/src/views/key_handler.rs
+++ b/gpui-app/src/views/key_handler.rs
@@ -8,6 +8,30 @@ pub(crate) fn handle_key_down(
     window: &mut Window,
     cx: &mut Context<Spreadsheet>,
 ) {
+    // The printable text this keystroke carries, if any: what the cell branch at the
+    // bottom would type. Ctrl, Alt and Cmd turn a key into a command, and control
+    // characters are handled by actions, never inserted.
+    let printable_chars: String = match &event.keystroke.key_char {
+        Some(key_char)
+            if !event.keystroke.modifiers.control
+                && !event.keystroke.modifiers.alt
+                && !event.keystroke.modifiers.platform =>
+        {
+            key_char.chars().filter(|c| !c.is_control()).collect()
+        }
+        _ => String::new(),
+    };
+
+    // A text key this handler consumes must not reach the platform's text path as well,
+    // or it comes back through the IME input handler (`ime.rs`) and lands in the cell
+    // on top of whatever the consuming branch did: macOS goes on to `insertText` for
+    // any keystroke the app leaves unhandled, and Windows and Linux do the equivalent.
+    // Stop propagation up front for the keys that carry text; the cell branch at the
+    // bottom, the one place that wants the platform to deliver, turns it back on.
+    if !printable_chars.is_empty() && this.focus_handle.is_focused(window) {
+        cx.stop_propagation();
+    }
+
     // Terminal owns focus: don't route keys to the grid
     if this.terminal_has_focus(window) {
         #[cfg(debug_assertions)]
@@ -930,44 +954,41 @@ pub(crate) fn handle_key_down(
         }
     }
 
-    if let Some(key_char) = &event.keystroke.key_char {
-        if !event.keystroke.modifiers.control
-            && !event.keystroke.modifiers.alt
-            && !event.keystroke.modifiers.platform
-        {
-            // Filter out control characters - let them be handled by actions instead
-            let printable_chars: String = key_char.chars()
-                .filter(|c| !c.is_control())
-                .collect();
-
-            if !printable_chars.is_empty() {
-                match this.mode {
-                    Mode::GoTo => {
-                        for c in printable_chars.chars() {
-                            this.goto_insert_char(c, cx);
-                        }
+    if !printable_chars.is_empty() {
+        match this.mode {
+            Mode::GoTo => {
+                for c in printable_chars.chars() {
+                    this.goto_insert_char(c, cx);
+                }
+            }
+            Mode::Find => {
+                for c in printable_chars.chars() {
+                    this.find_insert_char(c, cx);
+                }
+            }
+            Mode::HubPasteToken => {
+                for c in printable_chars.chars() {
+                    this.hub_token_insert_char(c, cx);
+                }
+            }
+            Mode::HubLink => {
+                for c in printable_chars.chars() {
+                    this.hub_dataset_insert_char(c, cx);
+                }
+            }
+            _ => {
+                // Cell text: while `focus_handle` holds focus the IME input handler
+                // (`ime.rs`) is registered and the platform delivers this text to it, so
+                // let the keystroke propagate and insert nothing here (see the note at
+                // the top of this function). Without that focus there is no handler and
+                // the keystroke is the only delivery.
+                if this.focus_handle.is_focused(window) {
+                    cx.propagate();
+                } else {
+                    for c in printable_chars.chars() {
+                        this.insert_char(c, cx);
                     }
-                    Mode::Find => {
-                        for c in printable_chars.chars() {
-                            this.find_insert_char(c, cx);
-                        }
-                    }
-                    Mode::HubPasteToken => {
-                        for c in printable_chars.chars() {
-                            this.hub_token_insert_char(c, cx);
-                        }
-                    }
-                    Mode::HubLink => {
-                        for c in printable_chars.chars() {
-                            this.hub_dataset_insert_char(c, cx);
-                        }
-                    }
-                    _ => {
-                        for c in printable_chars.chars() {
-                            this.insert_char(c, cx);
-                        }
-                        this.update_edit_scroll(window);
-                    }
+                    this.update_edit_scroll(window);
                 }
             }
         }

--- a/scripts/build-symbol-font.py
+++ b/scripts/build-symbol-font.py
@@ -52,6 +52,11 @@ def in_scope(cp: int) -> bool:
         return False
     if 0x3000 <= cp <= 0x9FFF or 0xFE00 <= cp <= 0xFE0F:
         return False  # CJK and variation selectors need their own fonts
+    if 0x1100 <= cp <= 0x11FF or 0xA960 <= cp <= 0xA97F or 0xAC00 <= cp <= 0xD7FF:
+        # Hangul, for the same reason, and it does not live next to the CJK block:
+        # syllables sit at U+AC00 and the jamo that compose them at U+1100, either
+        # side of the range above.
+        return False
     return True
 
 


### PR DESCRIPTION
Fixes #14.

Registers an `EntityInputHandler` for `Spreadsheet` so composing input
methods (Korean, Japanese, Chinese, dead keys) drive the cell editor
through marked text instead of dropping intermediate characters into it.
The second commit is the Hangul font-scope fix, kept separate as you
asked.

## On the five points

**1. The focus-handle guard is not enough.** Agreed, and my issue text
was wrong about GoTo/Find/Hub having their own handles: everything types
through the root `on_key_down` under `app.focus_handle`. What actually
doubles those buffers is that `handle_key_down` never stopped
propagation, so every platform hands the same key to the input handler
after the app already consumed it (macOS `insertText`, Windows through
`WM_GPUI_KEYDOWN` gating `TranslateMessage`, Linux the key_char
fallback). A mode check alone does not cover it, because several
consuming branches change the state before the re-delivery arrives (vim
`i` starts an edit, a hint letter exits Hint mode, a menu accelerator
closes the menu). So `handle_key_down` now stops propagation for text
keys up front, and only the cell branch turns it back on so the platform
makes its delivery there. `accepts_text_input`, which on macOS decides
whether an active IME composes a printable key before the app sees it,
is true for Ready and editing cells so first-keystroke composition
works, and false only where a Navigation letter is a command (vim
motions, the Names inspector filter). Those branches stay where they
are; moving them behind the handler is the larger refactor you wanted
to keep separate.

**2. Committed text goes through `insert_char`.** Done.
`replace_text_in_range` removes what the commit replaces (the marked
run, or an explicit range from the platform) and then calls
`insert_char` per character, with the same control-character filter as
the key-down path; a plain selection is left for `insert_char` to
delete, so both paths share that code. Provisional (marked) text still
writes into `edit_value` directly, since it is not committed yet, but it
clears the pending formula reference the way a non-operator keystroke
does and runs the same post-mutation tail as `insert_char`. `=1+2`
typed through the handler evaluates to 3 on the live build.

**3. The four test cases.** All four are `Spreadsheet` mode transitions,
and `gpui-app` has no harness that builds a `Spreadsheet` outside a
window (nothing here turns on gpui's `test-support`), so I verified them
on the real keyboard rather than as unit tests (table below):

- Composing on a Ready cell starts editing: the handler calls
  `start_edit_clear` before marking. Verified (A3, A5, A6).
- Enter unmarks and commits: on macOS the Korean IM commits the
  syllable via `insertText` and hands Enter back through
  `doCommandBySelector`, so the commit runs first and `reset_edit_state`
  clears the mark. Verified (A5).
- Escape mid-composition follows the existing Excel/vim split in
  `actions_edit.rs`, untouched; `reset_edit_state` is on both branches.
  Verified for the Excel default (A4).
- Leaving the cell mid-composition: `reset_edit_state` clears the mark
  and the selection anchor on every commit and cancel, both edit entry
  points clear them too, and a mark is only honoured while editing and
  inside the buffer on char boundaries. So the exits that assign `mode`
  directly (Find, GoTo, palette, F12) cannot leave a live run behind.
  Verified with Down (A6); the click path is `commit_pending_edit`,
  which calls the same reset.

What the unit tests do cover: the marked run is what a `None` range
targets while composing; a commit removes exactly that run and parks the
caret there; empty marked text clears the mark; a commit with no
composition removes nothing (the ASCII case); and offsets inside a
character round down instead of panicking (autocomplete can leave the
cursor there). If you want the four transitions as real tests, I am
happy to follow up with a change that enables `test-support` and drives
a `Spreadsheet` in a `VisualTestContext`; it felt like its own PR.

**4. `bounds_for_range`.** Returns the formula-bar text rect when that
surface is active, and otherwise the active cell's rect, using the same
`active_cell_rect` + `grid_body_origin` composition `open_context_menu`
uses. Placing the candidate window under the caret within the cell needs
a shaped line and is the follow-up you offered; I have no Japanese or
Chinese source here to check candidate placement against, so the cell is
as far as I can verify.

**5. Split view.** `SplitPane` allocates a `FocusHandle`
(`split_view.rs:78`), but nothing tracks or focuses it (no `track_focus`
for it, and `active_focus_handle()` has no callers), so keys in the
right pane flow through the same root listener under `app.focus_handle`
and the handler is registered either way. I could not exercise split
view on the keyboard, so I am noting this rather than claiming it works;
if you can reproduce a case where the right pane does not compose, I will
chase it.

## Real-keyboard verification on this branch

macOS 26.4.1, Apple Silicon, debug build at the PR head. Keys sent
through the system key path, input source switched with the TIS API,
read back with `vgrid inspect`.

Composition, commit and the edit lifecycle (2-Set Korean and ABC):

| Cell | Sent | Got |
| --- | --- | --- |
| A1 | ABC `a s d`, Enter | `asd` (no doubling) |
| A2 | ABC `= 1 + 2`, Enter | raw `=1+2`, display `3` |
| A3 | Korean `g k s r m f`, Enter | `한글` (U+D55C U+AE00) |
| A4 | Korean `g k s`, Escape; then ABC `x`, Enter | `x` (Escape abandoned the composition and the edit; the next key started clean) |
| A5 | Korean `g k s`, Enter mid-composition | `한` |
| A6 | Korean `g k s`, Down mid-composition | `한`, selection moved to A7 |
| A7 | ABC `a 9`, Enter | `a9` |
| A9 | Cmd+G, `a 9`, Enter; then `o k`, Enter | GoTo jumped to A9, nothing leaked into a cell, A9 = `ok` |

The propagation change, in the modes where a text key is a command
rather than cell input (vim and hints enabled for this run):

| Mode | Sent | Got |
| --- | --- | --- |
| vim insert | `i`, then `h i`, Escape | cell = `hi` (the `i` that entered insert did not leak) |
| vim motion | `w` on an empty cell, Enter | no edit started, cell empty |
| keyboard hints | `g g` | jumped to the top, nothing typed into a cell |
| command palette | Cmd+Shift+P, `a b c`, Escape | filtered the palette, nothing leaked into a cell |

`cargo test -p visigrid-gpui`: 501 passed, 0 failed, 3 ignored (486
before, 15 new).

## Not verified here

- Linux and Windows are not built or run on my machine. The code uses
  only cross-platform gpui APIs, and as you noted the wayland/x11 paths
  fall through to `replace_text_in_range`, so the same gate applies;
  I just cannot confirm it. You mentioned you would check Wayland.
- The candidate-window position for an IME that shows one (Japanese,
  Chinese). I have neither source installed.
- Two clippy lints fire on my toolchain at `grid.rs:882` and
  `inspector_panel.rs:476`, both pre-existing on `main` and untouched
  here; they look like a newer clippy than CI's flagging existing code.

## Left for follow-ups, in case you want them

- The post-edit tail (recompute mode, refs, autocomplete, notify) is
  inlined five times in `editing.rs`; `ime.rs` adds a sixth for the
  marked path. A shared `after_edit_buffer_change` would remove the
  pairing, but it touches five existing call sites.
- `is_in_scope` (the Rust test) and `in_scope` (the Python script)
  remain two hand-synced scope tables; a single source parsed by both
  would remove the "kept identical" comment.
